### PR TITLE
Fix headings in markdown and typos in source link

### DIFF
--- a/_posts/2014-11-10-Instagram-with-Material-Design-concept-is-getting-real.md
+++ b/_posts/2014-11-10-Instagram-with-Material-Design-concept-is-getting-real.md
@@ -14,7 +14,7 @@ While it's only graphic prototype some people started to wonder if it's possible
 
 Regarding to this I want to start new series of posts in which I'll show you how to reproduce *[INSTAGRAM with Material Design]* on real Android devices. Of course, for obvious reasons we'll create only front-end mockup for this application, but we'll try to reproduce as many details as it's possible.
 
-#Starting the project
+# Starting the project
 In this post I'd like to reproduce first 7 seconds of showed concept. I think it's enought for the first time, regarding to that we also have to prepare and configure our project.
 
 I'd like you to remember that all solutions which I'll show you are not the only possible ways - they are my favorite ones. Also I'm not a graphic designer so all images used in our project are taken from public resources (mainly from Material Design avaiable on it's [resources page]).
@@ -61,7 +61,7 @@ Basing on concept movie we'll define three base colors for our `AppTheme`:
 
 More details about what these colors are, you can find in [Material Theme Color Palette documentation].
 
-###Layout
+### Layout
 Our current project will be build from 3 main layout elements:
 
 * **Toolbar** - top bar with navigation icons and application logo
@@ -280,8 +280,8 @@ And... that's all! If we build and run our project we have the final version sho
 
 In case you missed something, here is [commit for our project with implemented animations].
 
-##Source code
-Ful source code of described example is available on Github [repository].
+## Source code
+Full source code of described example is available on Github [repository].
 
 *Author: [Miroslaw Stanek]*
 

--- a/_posts/2014-11-2-MultiDex-solution-for-64k-limit-in-Dalvik.md
+++ b/_posts/2014-11-2-MultiDex-solution-for-64k-limit-in-Dalvik.md
@@ -182,7 +182,7 @@ With Android 5.0 Lollipop release, new support library appeared in Android SDK. 
 
 Where using MultiDex is pretty simple it's some important things which we should care about. 
 
-###Configuring project
+### Configuring project
 First of all we have to configure build instructions to split our project into multiple dex files. 
 
 In `app/build.gradle` file we have to add:
@@ -284,7 +284,7 @@ Now after we build and run our project everything works as it should.
 
 Here you have [3rd commit] with complete changes required for enabling MultiDex support.
 
-###Possible problems
+### Possible problems
 It's good to keep in mind these important things:
 
 * Additional .dex files are loaded in `Application.attachBaseContext(Context)` method (by `MultiDex.install(Context)` invokation). It means, that before this moment we can't use classes from them. So i.e. we cannot declare static fields with types attached out of main .dex file. Otherwise we'll get `java.lang.NoClassDefFoundError`. 
@@ -324,8 +324,8 @@ android/support/multidex/ZipUtil$CentralDirectory/class
 android/support/multidex/ZipUtil/class
 {% endhighlight %}
 
-##Source code
-Ful source code of described example is available on Github [repository].
+## Source code
+Full source code of described example is available on Github [repository].
 
 *Author: [Miroslaw Stanek]*
 

--- a/_posts/2014-11-25-Instagram-with-Material-Design-concept-part-2-Comments-transition.md
+++ b/_posts/2014-11-25-Instagram-with-Material-Design-concept-part-2-Comments-transition.md
@@ -14,7 +14,7 @@ This is the final effect described in today's post (for both Android Lollipop an
 
 <iframe width="420" height="315" src="//www.youtube.com/embed/b8OOaluag-w" frameborder="0" allowfullscreen></iframe>
 
-#Initial config
+# Initial config
 
 Let's start from adding boilerplate and less important stuff to our [previously created project]. We have to add:
 
@@ -125,8 +125,8 @@ The last thing that we have to implement is exit transition. Basing on concept v
 
 And that's all! We've just finished second step of InstaMaterial concept implementation. In next post I want to focus on details which we currently missed.
 
-##Source code
-Ful source code of described example is available on Github [repository].
+## Source code
+Full source code of described project is available on Github [repository].
 
 *Author: [Miroslaw Stanek]*
 

--- a/_posts/2014-12-05-InstaMaterial-concept-part-3-feed-and-comments-buttons.md
+++ b/_posts/2014-12-05-InstaMaterial-concept-part-3-feed-and-comments-buttons.md
@@ -14,14 +14,14 @@ This is the final effect described in today's post (for both Android Lollipop an
 
 <iframe width="420" height="315" src="//www.youtube.com/embed/6ill09PZOFg" frameborder="0" allowfullscreen></iframe>
 
-#Initial config
+# Initial config
 
 Nothing special is happening here. We only need to add two images for buttons in feed element (**like** and **comment** icons) and modify current mock images. It was done in [this commit]. After that, but still before we'll start to implement the new stuff, we have to work on...
 
-#Bugfixes and performance improvements
+# Bugfixes and performance improvements
 That's right, even in small projects like **InstaMaterial** you can always find something to fix or to improve. The same is here.
 
-##Toolbar theme
+## Toolbar theme
 First of all I missed the Toolbar styling. And that's why selector for menu button (left button on the Toolbar) has default, dark version (screen below). 
 
 ![Toolbar without styling](/images/4/toolbar_without_styling.png "Toolbar without styling")
@@ -40,12 +40,12 @@ After we'll apply new them menu selector should look like below (Lollipop only):
 
 ![Toolbar with styling](/images/4/toolbar_with_styling.png "Toolbar with styling")
 
-##RecyclerView elements preloading
+## RecyclerView elements preloading
 Another problem I found in project is feed scroll smoothness right after we launch the app. Almost every time we scroll to the second item, layout stutters for a while. Fortunately the reason of this problem is quite simple. As you probably know `RecyclerView` (and other adapter views like `ListView`, `GridView` etc.) uses recycle mechanism for reusing views (in short, system keeps in memory layout only for items which are visible on screen, and reuse them instead of creating new ones if you scroll it).
 
 The problem with our project is that we have only one feed element visible on the screen after we start the application. When we start scrolling, there are no views to reuse by `RecyclerView`, so in the moment when we reach the second element it has to be layed out. Unfortunately it takes some time, so our `RecyclerView` stutters for this moment. After that scroll becomes smooth because we had at least two elements in memory to reuse (which we don't need to create from scratch).
 
-###How to fix this? 
+### How to fix this? 
 
 In our example it's pretty straightforward thanks to `LinearLayoutManager` which we use. All we have to do is to override `getExtraLayoutSpace()` method. According to the [documetation], it should return amount of extra space (in **pixels**) that should be laid out by our LayoutManager:
 
@@ -61,12 +61,12 @@ and after it:
 
 ![RecyclerView stuttering fixed](/images/4/not_stuttered.gif "RecyclerView stuttering fixed")
 
-#Feed buttons
+# Feed buttons
 Let's start with feed buttons (**like** and **comments** for now). As we can see on the [concept video] they have fancy, circle-shaped selector. 
 
 ![Ripple effect](/images/4/ripple.gif "Ripple effect")
 
-##Ripples in Android Lollipop.
+## Ripples in Android Lollipop.
 Selectors used in feed buttons are nothing more than the **Ripple** effect introduced in Android Lollipop. There are a lot of tutorials and blog posts about ripples so I don't want to dive into this topic so deeply. here are a couple links:
 
 * [Ripples – Part 1] and [Ripples – Part 2] from **Styling Android blog**
@@ -82,14 +82,14 @@ And this is how we use it in `feed_item.xml` as a buttons background (line 17 an
 
 {% gist frogermcs/58a327605fc020354658 item_feed.xml %}
 
-##Don't use ripples in pre-21 Android version
+## Don't use ripples in pre-21 Android version
 I know that I promised to reproduce almost everything from the [concept video], but sometimes it is better to not do something rather than do something which doesn't meet the expectations. And so it is with the ripple effect in pre-21 Android versions.
 
 Of course right now we have some libraries which [mimic ripple effect] on older Androids, but none of them work as it should. They need extra code (i.e. additional layout wrapper), don't use native **Ripple** effect in Android Lollipop, have performance issues etc.
 
 But why is so hard to copy **Ripple** effect into pre-21 Android?
 
-###Ripples - under the hood
+### Ripples - under the hood
 Before Android Lollipop whole UI was managed in one "main" thread - UI Toolkit thread. Almost everyone knows [ANR] dialogs, the most of us faced with [NetworkOnMainThreadException] and knows the golden rule - move all long-running operations (networking, database access, image processing) to worker threads and handle only the results in UI thread. And everything would be ok except one rule from first sentence - whole UI have to be managed in main thread.
 
 With more complex and rich apps layouts, The UI itself becomes much more demanding and needs more time for measure, draw and layout operations. And here is the problem. If we are in the middle of animation and start another UI task (like inflating layout for newly opened Acitvity) the problem is that both of these tasks are performed in the same thread, so that animation is going to stop while the activity launches.
@@ -100,14 +100,14 @@ And actually this is how ripples work. They are executed in render thread, compl
 
 And that's why there is no (simple) way to achieve ripple effect in pre-21 Android system.
 
-##Pre-ripple selector in older Android 
+## Pre-ripple selector in older Android 
 Because wa cannot do ripples let's make something similar. We create circle selector with enter and exit fade duration. Maybe it's not as effecitve as ripples, but still looks ok. Here is an example:
 
 And the implementation of `res/drawable/btn_feed_action.xml`:
 
 {% gist frogermcs/58a327605fc020354658 btn_feed_action.xml %}
 
-#Send comment button
+# Send comment button
 Much more interesting for us is **SendCommentButton**. As you can notice on the [concept video] it has two states with simple translate animation between them and ripple onClick selector. 
 
 ![Send comment button](/images/4/send_comment.gif "Send comment button")
@@ -118,7 +118,7 @@ For this button we'll use a couple Android elements:
 * Custom view composed in .xml and inflated in code
 * `<merge>` tag for eliminate redundant view groups
 
-##Implementation
+## Implementation
 
 Ok, let's start from the animations. Actually we need four of them - 2 (enter and exit) for Send state and 2 (enter and exit, but reversed) for Done state:
 
@@ -161,7 +161,7 @@ The rest is quite simple. By invoking `setInAnimation()` and `setOutAnimation()`
 
 Great, we've just finished `SendCommentButton` implementation.
 
-##Design
+## Design
 The same as in feed action buttons, we have to prepare two different selectors for our `SendCommentButton`. For Lollipop version again we'll use ripple effect (this time bounded in button frame). For pre-21 Android we'll create standard version with pressed state and shadow emulated in the same way like FAB button described in the first post of this series.
 
 Here is the code for both .xml files:
@@ -172,7 +172,7 @@ Here is the code for both .xml files:
 `res/drawable/btn_send_comment.xml`:
 {% gist frogermcs/58a327605fc020354658 btn_send_comment.xml %}
 
-##Bonus - shake on error
+## Bonus - shake on error
 At the end we'll add one more functionality not showed in the [concept video] - shake animation in case comment text field will be empty. Here is the preview of this effect (it looks much better on the real device):
 
 ![Error shaking](/images/4/shake_error.gif "Error shaking")
@@ -191,7 +191,7 @@ If we want to use it in code we have start this animation of View like below:
 
 And that's all for today! Here is the [last commit] with our `SendCommentButton` usage (it's only a boilerplate not worth mentioning). In the next post we'll finally move on to the next period in concept video.
 
-##Source code
+## Source code
 Full source code of described example is available on Github [repository].
 
 *Author: [Miroslaw Stanek]*

--- a/_posts/2014-12-19-InstaMaterial-concept-part-4-feed-context-menu.md
+++ b/_posts/2014-12-19-InstaMaterial-concept-part-4-feed-context-menu.md
@@ -14,7 +14,7 @@ This is the final effect described in today's post (for both Android Lollipop an
 
 <iframe width="420" height="315" src="//www.youtube.com/embed/DNT7j0JjrtE" frameborder="0" allowfullscreen></iframe>
 
-#Warming up
+# Warming up
 
 Before we start working with context menu let's do some refactoring. 
 
@@ -32,9 +32,9 @@ It's worth mentioning that we can override properties in `<include />` tag (they
 
 Here is the [commit] with described refactoring.
 
-#Context menu
+# Context menu
 
-##Initial config
+## Initial config
 
 As usual let's make some preparation before we start coding. Here is the screenshot of desired effect:
 
@@ -42,7 +42,7 @@ As usual let's make some preparation before we start coding. Here is the screens
 
 First of all we have to add another button to our `item_feed.xml` layout and handle its `onClick()` event. Pretty straighforward, just copy and paste some previous code and add missing three-dots image (I used [this one] from official Material Design icons pack). Here is [full commit] with these changes.
 
-##Context menu layout
+## Context menu layout
 Let's start from our view's layout. One more time we'll use `<merge />` tag and construct our view from .xml and java code. 
 
 `res/layout/view_context_menu.xml` is simple:
@@ -134,7 +134,7 @@ As you can see it's a little tricky. In the same time when our menu is hiding we
 
 All we have to do right now is to make usage from our `FeedContextMenuManager`. Here is [the last commit] which shows how we did it in our project. That's all for today. 😄
 
-##Source code
+## Source code
 Full source code of described example is available on Github [repository].
 
 *Author: [Miroslaw Stanek]*

--- a/_posts/2015-01-06-InstaMaterial-concept-part-5-like_action_effects.md
+++ b/_posts/2015-01-06-InstaMaterial-concept-part-5-like_action_effects.md
@@ -14,7 +14,7 @@ This is the final effect described in today's post (for both Android Lollipop an
 
 <iframe width="420" height="315" src="//www.youtube.com/embed/KbJQ99EY5Yk" frameborder="0" allowfullscreen></iframe>
 
-#Like the feed item
+# Like the feed item
 
 Based on the [concept video], in our project we have two ways for liking feed item - like by heart button and by click on photo (actually I'm pretty sure that it should work after double click, just like in the real Instagram app, but let it be small exercise for you to implement double-click handler 😄).
 
@@ -26,7 +26,7 @@ As usual we have to update and add some resources used in our project. Today we 
 
 (starting from left: heart for likes counter, heart for liked button, heart for photo like animation).
 
-##Likes counter
+## Likes counter
 Let's start from the simplest effect. Like counter should be updated with in/out animation (old value goes up, while the new one comes from down). This is how it looks in practice:
 
 ![Likes counter](/images/6/likes_counter.gif "Likes counter")
@@ -47,7 +47,7 @@ And here is the visual preview from Android Studio for added view:
 
 `android:inAnimation` and `android:outAnimation` values are used for transition between previous and next child.
 
-###0dp for better performance
+### 0dp for better performance
 
 `LinearLayout` which wraps our likes counter uses `layout_weight="1"` (keep in mind that its *parent* is also the `LinearLayout`). When only one child of `LinearLayout` uses weight value it will absorb all the remaining space in parent (like in our case - look on the screenshot above). By using `layout_width="0dp"` (or height in vertical oriented LinearLayouts) we made a little perfromance improvement because our view doesn't have to measure its own size first.
 
@@ -62,12 +62,12 @@ This method is used for updating likes counter in two ways:
 
 Also, as you probably noticed, we are using *Quantity Strings* for proper handling words with quantity. Here you can find more details about using [Plurals] in Android.
 
-##Button like animation
+## Button like animation
 Now we'll focus on like button animation. Its behavior is a little bit fancier than on [concept video] and looks like on the screenshot below:
 
 ![Heart button](/images/6/heart_button.gif "Heart button")
 
-###Bundling multiple animations
+### Bundling multiple animations
 This effect is composed from multiple animations bundled in one set. That's why we cannot use `ViewPropertyAnimator` like we did before. Fortunately there is a simple way to play multiple animations which are depends on each other. Thanks to [AnimatorSet] we can bundle animations together and play them simultaneously, sequentially or in the mixed way. It's described wider there: [Choreographing Multiple Animations]
 
 Our like button effect is composed from 3 animations:
@@ -85,7 +85,7 @@ This time we used `ObjectAnimator` which can animate properties of target object
 
 Here is full commit which adds [like button animation].
 
-##Photo like animation
+## Photo like animation
 
 A little bit more complex is photo like animation. This time we animate values of two different objects (but still in one `AnimatorSet`):
 
@@ -104,7 +104,7 @@ Again we used `ObjectAnimator` and `AnimatorSet` (composition in lines 40-41).
 
 And that's all for today, thanks for reading! 😄
 
-##Source code
+## Source code
 Full source code of described project is available on Github [repository].
 
 *Author: [Miroslaw Stanek]*

--- a/_posts/2015-01-23-InstaMaterial-concept-part-6-user-profile.md
+++ b/_posts/2015-01-23-InstaMaterial-concept-part-6-user-profile.md
@@ -14,11 +14,11 @@ This is the final effect described in today's post (for both Android Lollipop an
 
 <iframe width="420" height="315" src="//www.youtube.com/embed/NGyoszveMw4" frameborder="0" allowfullscreen></iframe>
 
-#Introdution
+# Introdution
 
 Honestly if you read carefully my previous posts and tried to implement described effects and views, today you won't learn anything new. Even if the final effect looks very complex almost every used technique or tool were described previously. Actually it's a good news - the number of different solutions in Android platform is finite. But the way in which you use them is limited only by your imagination. 😄
 
-#Preparation
+# Preparation
 
 As always let's start from adding new elements. We have to create new `UserProfileActivity` with Toolbar, RecyclerView and FloatingActionButton. Because of custom transition it should use the same style which we used in `CommentsActivity`. Also we have to add onClick listener to profile photo in `FeedAdapter`. And by the way I did small refactoring by creating BaseActivity. Here you have list of commits:
 
@@ -148,7 +148,7 @@ And the full commit with all required changes is [available here].
 
 That's all for today. We've just finished user profile with opening transition and all animations. thanks for reading! 😄
 
-##Source code
+## Source code
 Full source code of described project is available on Github [repository].
 
 *Author: [Miroslaw Stanek]*

--- a/_posts/2015-01-31-InstaMaterial-concept-part-7-navigation-drawer.md
+++ b/_posts/2015-01-31-InstaMaterial-concept-part-7-navigation-drawer.md
@@ -18,7 +18,7 @@ Here is the final effect described in today's post:
 
 <iframe width="420" height="315" src="//www.youtube.com/embed/rRYN1le1-ZM" frameborder="0" allowfullscreen></iframe>
 
-#Introdution
+# Introdution
 
 Navigation Drawer is a very well known design pattern used in Android (and other mobile platforms). It's a panel that transitions in from the left edge of the screen and displays the app’s main navigation options. Sometimes it transitions in from the right edge, but until you have a good reason for this, it's rather bad design implementation, which you shouldn't copy.
 
@@ -26,9 +26,9 @@ Navigation Drawer pattern is also well documented (from both - design and progra
 
 In this post, instead of copying the documentation, we'll prepare **DrawerLayoutInstaller** - a stub of simple tool, which can help us to configure and inject `DrawerLayout` into every Activity whithout messing with each xml file. 
 
-#Navigation Drawer implementation
+# Navigation Drawer implementation
 
-##Preparation
+## Preparation
 
 Before we start, let's make some preparation by adding resources, and less meaning boilerplate.
 
@@ -51,7 +51,7 @@ Our menu is built on top of `ListView`, so we have to prepare layout for list it
 
 Here is the [full commit with all new resources].
 
-##GlobalMenuView
+## GlobalMenuView
 Now let's prepare layout for our global menu. Basically it's a simple `ListView` and we could build it in xml file. But in case when we want to inject this view into more Activities it's better to prepare it programmatically.
 
 Requirements for this view are simple - just display options list and user profile. So the implementation isn't too complicated:
@@ -62,14 +62,14 @@ As you probably noticed, user profile view is used as ListView's header. That's 
 
 `GlobalMenuAdapter` is even simpler, so I won't paste source code here. Instead, check this [commit with GlobalMenuView implementation].
 
-##Navigation Drawer
+## Navigation Drawer
 Now it's time to create Navigation Drawer implementation. First of all let's prepare xml root view for our `DrawerLayout`:
 
 {% gist frogermcs/44f57794ed7e86bf51c3 drawer_root.xml %}
 
 This generic layout can host custom root view (in **vContentFrame** element) and custom left drawer item (**vLeftDrawer** element).
 
-###DrawerLayoutInstaller
+### DrawerLayoutInstaller
 
 Now it's time to prepare our tool for injecting `DrawerLayout` into `Activity` layout tree. Probably **DrawerLayoutInstaller** will be developed in the future but now the requirements list is short and simple:
 
@@ -103,7 +103,7 @@ In this case handler delays opening until DrawerLayout closes. Here is the final
 
 That's all for today. It was super fast and simple, as always it should be. Thanks for reading! 😄
 
-##Source code
+## Source code
 Full source code of described project is available on Github [repository].
 
 *Author: [Miroslaw Stanek]*

--- a/_posts/2015-02-14-InstaMaterial-concept-part-8-capturing-photo.md
+++ b/_posts/2015-02-14-InstaMaterial-concept-part-8-capturing-photo.md
@@ -16,7 +16,7 @@ Now let's back to this post - here is the final effect which we want to achieve 
 
 <iframe width="420" height="315" src="//www.youtube.com/embed/0w3lGJIISTo" frameborder="0" allowfullscreen></iframe>
 
-#Introdution
+# Introdution
 
 Almost all solutions and animations described today were presented in previous posts. That's why I won't focus on detailed descriptions. But also there will be completely new element - camera. Those who have worked with it before know that this compoment is a little bit problematic for implementation. Why? In short - Android as an opened platform can handle very wide range of devices with completely different hardware (especially camera) specification. So if you are starting your work with picture capturing here is short list of things you should care:
 
@@ -33,7 +33,7 @@ According to some points described above, instead of writing my own implementati
 
 And the last thing before we start. Camera implemetation in InstaMaterial app is very limited. There is no logic for picture file handling and captured image displaying is very tricky. A lot of work should be done before this code will be ready for production (especially with bitmap cropping, picking right size for image etc.). But I trust that it could be good codebase for more complicated projects. 😄
 
-#Preparation
+# Preparation
 As always let's add some resources and less important boilerplate. Also some libraries have been updated. From now project has also new structure:
 
 ![Project structure](/images/9/project_structure.png "Project structure")
@@ -46,7 +46,7 @@ Here is list of commits:
 * [project structure update]
 * [new required resources]
 
-##CWAC-Camera configuration
+## CWAC-Camera configuration
 Camera library installation is very simple. All we have to do is add new maven repository in `<project>/build.gradle` file:
 
 {% highlight groovy %}
@@ -70,7 +70,7 @@ Finally we have to add new permissions in `AndroidManifest.xml` file:
 
 {% gist frogermcs/e2d00a89cef336779bf1 AndroidManifest.xml %}
 
-#Photo capture screen
+# Photo capture screen
 Now we can start implementation of capture screen. I considered two ways of implementation - two different activities for taking photo and editing it or one activity with these states. First option is more correct in my opinion (and probably I would use it in production code) but finally I took second one. Why? Because there is no simple way (but it isn't impossible!) to make transition from camera preview to taken photo preview without little layout hickup. By default camera saves taken picture on external storage and another activity should read it from that place. Unfortunately it generates a little delay so we would have to figure out some solution for passing bitmap between two activities (something more complex than sending bitmap via Intent's bundle or saving bitmap as a static field).
 
 Let's start from intro animation. For Activity transition we can use `RevealBackgroundView` introduced in [one of the previous posts]. One more time we have to pass starting location (taken from FAB button this time). The only difference is that we have to add new style which hides status bar in `TakePhotoActivity`:
@@ -83,7 +83,7 @@ and set it in `AndroidManifest` file:
 
 Commit with all described changes is [available here].
 
-#TakePhotoActivity layout
+# TakePhotoActivity layout
 Now let's prepare layout for capture screen. As I mentioned it should handle two states - capturing and configuring photo. That's why we should implement elements transitions. For this we'll use `ViewSwitcher` which can handle animation between his children (in our project we used `TextSwitcher` for likes counter animation which extends `ViewSwitcher` class).
 
 Before we start layout implementation we should prepare background for capture button:
@@ -112,7 +112,7 @@ Top and bottom panels slide from the right side of screen (thanks to `ViewSwitch
 
 Here is the [full source code] of .xml file.
 
-#Photo capturing view implementation
+# Photo capturing view implementation
 Finally we can implement the most important thing - photo capturing. In short here is the list of requirements:
 
 * Intro animation (sliding-in top and bottom panels right after background reveal animation)
@@ -123,7 +123,7 @@ First point is pretty straightforward. Just hide top and bottom panels on Acitiv
 
 {% gist frogermcs/e2d00a89cef336779bf1 TakePhotoActivity_intro.java %}
 
-##Photo capturing
+## Photo capturing
 Now we have to configure `CameraView`. According to [CWAC-Camera documentation] we have to integrate this view with Activity lifecycle (onResume() and onPause() mehtods):
 
 {% highlight java %}
@@ -163,7 +163,7 @@ Here is the full source code of [TakePhotoActivity].
 
 And that's all for today. Thank you all for the reading! 😄
 
-##Source code
+## Source code
 Full source code of described project is available on Github [repository].
 
 *Author: [Miroslaw Stanek]*

--- a/_posts/2015-03-31-dagger-1-to-2-migration.md
+++ b/_posts/2015-03-31-dagger-1-to-2-migration.md
@@ -14,7 +14,7 @@ As I said, I'm a big fan of DI and these drawbacks don't discourage me to use of
 
 Fortunately for us Dagger 2 came to *Not quite released, but stable, feature-completed state*. 
 
-#Dagger 2
+# Dagger 2
 I won't deep to much into technical details of the second major version this dependency injector. Instead, just check official [Dagger 2 website] and Devoxx talk about [The Future of Dependency Injection with Dagger 2] from Jake Wharton.
 
 What was a super-important for me, Dagger 2 almost automatically helps to solve a couple of problems which could take a lot of time with Dagger 1:
@@ -138,7 +138,7 @@ And that's all. Thank you for reading. I hope to deep Dagger 2 even more, so see
 ## Source code
 Full source code of described project is available on Github [repository].
 
-###Author
+### Author
 
 [Miroslaw Stanek]  
 *Head of Mobile Development* @ [Azimo]

--- a/_posts/2015-06-02-dependency-injection-with-dagger-2-introdution-to-di.md
+++ b/_posts/2015-06-02-dependency-injection-with-dagger-2-introdution-to-di.md
@@ -73,13 +73,13 @@ Much simpler right? Of course DI frameworks don't take objects from nowhere - th
 Everything I described above was a light background to Dagger 2 - dependency injection framework which can be used in Android and Java development. In next post I'll try to go through whole Dagger 2 API. In case you don't want to wait just try my [Github client example] which is built on top of Dagger 2 and was used with my presentation. Just a hint - `@Modules` and `@Components` are the places to construct/provide objects. `@Inject` are the places where our objects are used.  
 More detailed description - soon.
 
-#References
+# References
 
 - [DAGGER 2 - A New Type of dependency injection ](https://www.youtube.com/watch?v=oK_XtfXPkqw) by Gregory Kick
 - [The Future of Dependency Injection with Dagger 2 ](https://www.parleys.com/tutorial/the-future-dependency-injection-dagger-2) by Jake Wharton
 - [Dagger 1 to 2 migration process ](http://frogermcs.github.io/dagger-1-to-2-migration/)
 
-###Author
+### Author
 
 [Miroslaw Stanek]  
 *Head of Mobile Development* @ [Azimo]

--- a/_posts/2015-06-10-dependency-injection-with-dagger-2-the-api.md
+++ b/_posts/2015-06-10-dependency-injection-with-dagger-2-the-api.md
@@ -191,10 +191,10 @@ Also in this place we're providing AppComponent instance (because `SplashActivit
 
 The rest is up to you. Seriously - try to figure out how everything fits together. And in next post we'll try to take a look closely on Dagger 2 elements (how they work onder the hood).
 
-##Source code
+## Source code
 Full source code of described project is available on Github [repository].
 
-###Author
+### Author
 
 [Miroslaw Stanek]  
 *Head of Mobile Development* @ [Azimo]

--- a/_posts/2015-07-01-dependency-injection-with-dagger-2-custom-scopes.md
+++ b/_posts/2015-07-01-dependency-injection-with-dagger-2-custom-scopes.md
@@ -112,10 +112,10 @@ And that's it. We've just figured out how scopes work under the hood in Dagger 2
 
 And that's all for today. I hope that scopes will become even simpler to use from now. Thanks for reading!
 
-##Source code
+## Source code
 Full source code of described project is available on Github [repository].
 
-###Author
+### Author
 
 [Miroslaw Stanek]  
 *Head of Mobile Development* @ [Azimo]

--- a/_posts/2015-07-23-instamaterial-meets-design-support-library.md
+++ b/_posts/2015-07-23-instamaterial-meets-design-support-library.md
@@ -113,11 +113,11 @@ Now take a look at the final effect:
 
 And this is all for today. We've just updated InstaMaterial with new views and effects like `Snackbar`, `FloatingActionButton`, `TabLayout`, `CoordinatorLayout`, `AppBarLayout` and `CollapsingToolbarLayout`. All of them were provided from [Android Design Support Library].
 
-##Source code
+## Source code
 
 Full source code of described project is available on Github [repository].
 
-###Author
+### Author
 
 [Miroslaw Stanek]  
 *Head of Mobile Development* @ [Azimo Money Transfer]

--- a/_posts/2015-08-12-flatbuffers-in-android-introdution.md
+++ b/_posts/2015-08-12-flatbuffers-in-android-introdution.md
@@ -9,7 +9,7 @@ Several days ago Facebook announced big performance improvement in data handling
 
 While the results are very promising, at the first glance the implementation isn't too obvious. Also facebook didn't say too much. That's why in this post I'd like to show how we can start our work with FlatBuffers. 
 
-#FlatBuffers
+# FlatBuffers
 In short, [FlatBuffers] is a cross-platform serialization library from Google, created specifically for game development and, as Facebook showed, to follow the [16ms rule] of smooth and responsive UI in Android. 
 
 *But hey, before you throw everything to migrate all your data to FlatBuffers, just make sure that you need this. Sometimes the impact on performance will be imperceptible and sometimes [data safety] will be more important than a tens of milliseconds difference in computation speed.*
@@ -21,7 +21,7 @@ What makes FlatBuffers so effective?
 
 For the real numbers just check again [facebook article] about migrating to FlatBuffers or [Google documentation] itself.
 
-#Implementation
+# Implementation
 
 This article will cover the simplest way of using FlatBuffers in Android app:
 
@@ -31,7 +31,7 @@ This article will cover the simplest way of using FlatBuffers in Android app:
 
 Probably in the future we'll prepare more complex solution.
 
-##FlatBuffers compiler
+## FlatBuffers compiler
 
 At the beginning we have to get **flatc** - FlatBuffers compiler. It can be built from source code hosted in Google's [flatbuffers repository]. Let's download/clone it. Whole build process is described on [FlatBuffers Building] documentation. If you are Mac user all you have to do is:
 
@@ -41,7 +41,7 @@ At the beginning we have to get **flatc** - FlatBuffers compiler. It can be buil
 
 Now we're able to [use schema compiler] which among the others can generate model classes for given schema (in Java, C#, Python, GO and C++) or convert JSON to FlatBuffer binary file.
 
-##Schema file
+## Schema file
 Now we have to prepare schema file which defines data structures we want to de-/serialize. This schema will be used with flatc to create Java models and to transform JSON into Flatbuffer binary file.
 
 Here is a part of our JSON file:
@@ -91,7 +91,7 @@ Here is [RawDataReader] util which helps us to read raw files in Android app.
 
 At the end put `Repo`, `ReposList` and `User` somewhere in project's source code.
 
-###FlatBuffers library
+### FlatBuffers library
 
 FlatBuffers provides java library to handle this data format directly in java. Here is [flatbuffers-java-1.2.0-SNAPSHOT.jar] file. If you want to generate it by hand you have to move back to downloaded FlatBuffers source code, go to `java/` directory and use Maven to generate this library:
 
@@ -110,7 +110,7 @@ Methods which should interest us the most:
 - `parseReposListJson(String reposStr)` - this method initializes Gson parser and convert json String to Java objects.
 - `loadFlatBuffer(byte[] bytes)` - this method converts bytes (our repos_flat.bin file) to Java objects.
 
-#Results
+# Results
 
 Now let's visualize differences between JSON and FlatBuffers loading time and consumed resources. Tests are made on Nexus 5 with Android M (beta) installed.
 
@@ -137,11 +137,11 @@ See the difference? Json loading freezes ProgressBar for a while, making our int
 
 Whant to measure more? Maybe it's a good time to give a try to [Android Studio 1.3] and new features like Allocation Tracker, Memory Viewer and Method Tracer.
 
-##Source code
+## Source code
 
 Full source code of described project is available on Github [repository]. You don't need to deal with FlatBuffers project - all you need is in `flatbuffers/` directory.
 
-###Author
+### Author
 
 [Miroslaw Stanek]  
 *Head of Mobile Development* @ [Azimo Money Transfer]

--- a/_posts/2015-09-30-dagger-graph-creation-performance.md
+++ b/_posts/2015-09-30-dagger-graph-creation-performance.md
@@ -132,10 +132,10 @@ Performance improvement process is very individual. But if you would like to sha
 
 Thanks for your reading!
 
-##Source code
+## Source code
 Full source code of described project is available on Github [repository].
 
-###Author
+### Author
 
 [Miroslaw Stanek]  
 *Head of Mobile Development* @ [Azimo Money Transfer]

--- a/_posts/2015-12-22-twitters-like-animation-in-android-alternative.md
+++ b/_posts/2015-12-22-twitters-like-animation-in-android-alternative.md
@@ -103,7 +103,7 @@ And... That's all. 😃 As you can see, there is no magic here, but the final ef
 
 ## Source code
 
-Ful source code of described project is available on Github [repository].
+Full source code of described project is available on Github [repository].
 
 ### Author 
 

--- a/_posts/2016-10-18-activities-multibinding-in-dagger-2.md
+++ b/_posts/2016-10-18-activities-multibinding-in-dagger-2.md
@@ -73,7 +73,7 @@ And the final implementation of injection in Activity class:
 
 It’s pretty similar to our very first implementation, but as mentioned, the most important thing is that we don’t pass `ActivityComponent` object to our Activities anymore.
 
-##Example of use case — instrumentation tests mocking
+## Example of use case — instrumentation tests mocking
 
 Besides loose coupling and fixed circular dependency (Activity <-> Application) which not always is a big issue, especially in smaller projects/teams, let’s consider the real use case where our implementation could be helpful — mocking dependencies in instrumentation testing.
 


### PR DESCRIPTION
It seems that `kramdown` used by Jekyll is fussy about headings.

I noticed this when something was off at the end at http://frogermcs.github.io/dagger-graph-creation-performance/#any-other-solutions:

![image](https://cloud.githubusercontent.com/assets/2906988/19627575/115d5372-994a-11e6-9ba5-64e1482be903.png)
